### PR TITLE
Allow creation of replica's autoscaling target

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -7,4 +7,9 @@ module "autoscaling" {
   autoscaling_read    = merge({ min_capacity = var.read_capacity }, var.autoscaling_read)
   autoscaling_write   = merge({ min_capacity = var.write_capacity }, var.autoscaling_write)
   autoscaling_indexes = var.autoscaling_indexes
+
+  providers = {
+    aws        = aws
+    aws.no-tag = aws
+  }
 }

--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -7,11 +7,7 @@ resource "aws_appautoscaling_target" "table_read" {
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
-  lifecycle {
-    ignore_changes = [
-      tags_all,
-    ]
-  }
+  provider = aws.no-tag
 }
 
 resource "aws_appautoscaling_policy" "table_read_policy" {
@@ -43,11 +39,7 @@ resource "aws_appautoscaling_target" "table_write" {
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 
-  lifecycle {
-    ignore_changes = [
-      tags_all,
-    ]
-  }
+  provider = aws.no-tag
 }
 
 resource "aws_appautoscaling_policy" "table_write_policy" {
@@ -79,11 +71,7 @@ resource "aws_appautoscaling_target" "index_read" {
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
-  lifecycle {
-    ignore_changes = [
-      tags_all,
-    ]
-  }
+  provider = aws.no-tag
 }
 
 resource "aws_appautoscaling_policy" "index_read_policy" {
@@ -115,11 +103,7 @@ resource "aws_appautoscaling_target" "index_write" {
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 
-  lifecycle {
-    ignore_changes = [
-      tags_all,
-    ]
-  }
+  provider = aws.no-tag
 }
 
 resource "aws_appautoscaling_policy" "index_write_policy" {

--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -7,6 +7,7 @@ resource "aws_appautoscaling_target" "table_read" {
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31839
   provider = aws.no-tag
 }
 
@@ -39,6 +40,7 @@ resource "aws_appautoscaling_target" "table_write" {
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31839
   provider = aws.no-tag
 }
 
@@ -71,6 +73,7 @@ resource "aws_appautoscaling_target" "index_read" {
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31839
   provider = aws.no-tag
 }
 
@@ -103,6 +106,7 @@ resource "aws_appautoscaling_target" "index_write" {
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31839
   provider = aws.no-tag
 }
 

--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -1,11 +1,17 @@
 resource "aws_appautoscaling_target" "table_read" {
-  count = var.create_autoscaling_target && length(var.autoscaling_read) > 0 ? 1 : 0
+  count = length(var.autoscaling_read) > 0 ? 1 : 0
 
   max_capacity       = var.autoscaling_read["max_capacity"]
   min_capacity       = var.autoscaling_read["min_capacity"]
   resource_id        = "table/${var.table_name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
+
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "table_read_policy" {
@@ -13,7 +19,7 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
 
   name               = "DynamoDBReadCapacityUtilization:table/${var.table_name}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = var.create_autoscaling_target ? aws_appautoscaling_target.table_read[0].resource_id : "table/${var.table_name}"
+  resource_id        = aws_appautoscaling_target.table_read[0].resource_id
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
@@ -29,13 +35,19 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
 }
 
 resource "aws_appautoscaling_target" "table_write" {
-  count = var.create_autoscaling_target && length(var.autoscaling_write) > 0 ? 1 : 0
+  count = length(var.autoscaling_write) > 0 ? 1 : 0
 
   max_capacity       = var.autoscaling_write["max_capacity"]
   min_capacity       = var.autoscaling_write["min_capacity"]
   resource_id        = "table/${var.table_name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
+
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "table_write_policy" {
@@ -43,7 +55,7 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
 
   name               = "DynamoDBWriteCapacityUtilization:table/${var.table_name}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = var.create_autoscaling_target ? aws_appautoscaling_target.table_write[0].resource_id : "table/${var.table_name}"
+  resource_id        = aws_appautoscaling_target.table_write[0].resource_id
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 
@@ -59,13 +71,19 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
 }
 
 resource "aws_appautoscaling_target" "index_read" {
-  for_each = var.create_autoscaling_target ? var.autoscaling_indexes : {}
+  for_each = var.autoscaling_indexes
 
   max_capacity       = each.value["read_max_capacity"]
   min_capacity       = each.value["read_min_capacity"]
   resource_id        = "table/${var.table_name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
+
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "index_read_policy" {
@@ -73,7 +91,7 @@ resource "aws_appautoscaling_policy" "index_read_policy" {
 
   name               = "DynamoDBReadCapacityUtilization:table/${var.table_name}/index/${each.key}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = var.create_autoscaling_target ? aws_appautoscaling_target.index_read[each.key].resource_id : "table/${var.table_name}/index/${each.key}"
+  resource_id        = aws_appautoscaling_target.index_read[each.key].resource_id
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 
@@ -89,13 +107,19 @@ resource "aws_appautoscaling_policy" "index_read_policy" {
 }
 
 resource "aws_appautoscaling_target" "index_write" {
-  for_each = var.create_autoscaling_target ? var.autoscaling_indexes : {}
+  for_each = var.autoscaling_indexes
 
   max_capacity       = each.value["write_max_capacity"]
   min_capacity       = each.value["write_min_capacity"]
   resource_id        = "table/${var.table_name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
+
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "index_write_policy" {
@@ -103,7 +127,7 @@ resource "aws_appautoscaling_policy" "index_write_policy" {
 
   name               = "DynamoDBWriteCapacityUtilization:table/${var.table_name}/index/${each.key}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = var.create_autoscaling_target ? aws_appautoscaling_target.index_write[each.key].resource_id : "table/${var.table_name}/index/${each.key}"
+  resource_id        = aws_appautoscaling_target.index_write[each.key].resource_id
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 

--- a/modules/autoscaling/variables.tf
+++ b/modules/autoscaling/variables.tf
@@ -26,12 +26,6 @@ variable "autoscaling_indexes" {
   default     = {}
 }
 
-variable "create_autoscaling_target" {
-  description = "Whether to create autoscaling target resources"
-  type        = bool
-  default     = true
-}
-
 variable "table_name" {
   description = "DynamoDB table name"
   type        = string

--- a/modules/autoscaling/versions.tf
+++ b/modules/autoscaling/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.21"
+      source                = "hashicorp/aws"
+      version               = ">= 5.21"
+      configuration_aliases = [aws.no-tag]
     }
   }
 }

--- a/modules/replica/main.tf
+++ b/modules/replica/main.tf
@@ -13,9 +13,8 @@ module "replica_autoscaling" {
 
   count = var.autoscaling_enabled ? 1 : 0
 
-  table_name                = split("/", aws_dynamodb_table_replica.replica.global_table_arn)[1]
-  create_autoscaling_target = true
-  autoscaling_read          = merge({ min_capacity = var.read_capacity }, var.autoscaling_read)
-  autoscaling_write         = merge({ min_capacity = var.write_capacity }, var.autoscaling_write)
-  autoscaling_indexes       = var.autoscaling_indexes
+  table_name          = split("/", aws_dynamodb_table_replica.replica.global_table_arn)[1]
+  autoscaling_read    = merge({ min_capacity = var.read_capacity }, var.autoscaling_read)
+  autoscaling_write   = merge({ min_capacity = var.write_capacity }, var.autoscaling_write)
+  autoscaling_indexes = var.autoscaling_indexes
 }

--- a/modules/replica/main.tf
+++ b/modules/replica/main.tf
@@ -14,7 +14,7 @@ module "replica_autoscaling" {
   count = var.autoscaling_enabled ? 1 : 0
 
   table_name                = split("/", aws_dynamodb_table_replica.replica.global_table_arn)[1]
-  create_autoscaling_target = false
+  create_autoscaling_target = true
   autoscaling_read          = merge({ min_capacity = var.read_capacity }, var.autoscaling_read)
   autoscaling_write         = merge({ min_capacity = var.write_capacity }, var.autoscaling_write)
   autoscaling_indexes       = var.autoscaling_indexes

--- a/modules/replica/main.tf
+++ b/modules/replica/main.tf
@@ -17,4 +17,9 @@ module "replica_autoscaling" {
   autoscaling_read    = merge({ min_capacity = var.read_capacity }, var.autoscaling_read)
   autoscaling_write   = merge({ min_capacity = var.write_capacity }, var.autoscaling_write)
   autoscaling_indexes = var.autoscaling_indexes
+
+  providers = {
+    aws        = aws
+    aws.no-tag = aws.no-tag
+  }
 }

--- a/modules/replica/versions.tf
+++ b/modules/replica/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.21"
+      source                = "hashicorp/aws"
+      version               = ">= 5.21"
+      configuration_aliases = [aws.no-tag]
     }
   }
 }


### PR DESCRIPTION
A replica's autoscaling target are automatically created by AWS when creating the replica.
An attempt to create the same atuoscaling target in terraform will result in the following error:
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/098542dd-e7d3-447a-841b-c0ed8fbd292a">

Notice that the error is specifically talking about the failure when applying the tag.
Hence, we can work around this error by not specifying the tags and voila, terraform will gladly create (take over management) of the autoscaling target.

This adds an option for users to supply `aws.no-tag` provider to `replica` and `autoscaling` module.
The provider will be used to create the autoscaling targets only.

Tested on sandbox env.